### PR TITLE
Add team rankings, player stats and live score WebSocket

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,13 +1,38 @@
 # main.py
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from redis import Redis
 from dotenv import load_dotenv
+import asyncio
 import os
+from typing import List
 
 load_dotenv()
 app = FastAPI()
 redis = Redis(host="redis", port=6379, decode_responses=True)
+
+
+class ConnectionManager:
+    def __init__(self) -> None:
+        self.active_connections: List[WebSocket] = []
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self.active_connections.append(websocket)
+
+    def disconnect(self, websocket: WebSocket) -> None:
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
+
+    async def broadcast(self, message: dict) -> None:
+        for connection in list(self.active_connections):
+            try:
+                await connection.send_json(message)
+            except WebSocketDisconnect:
+                self.disconnect(connection)
+
+
+manager = ConnectionManager()
 
 # Rate limiting middleware
 @app.middleware("http")
@@ -24,6 +49,66 @@ async def get_live_scores():
     if cached_data:
         return {"data": cached_data, "source": "cache"}
     # Fetch from external API (mock)
-    live_data = {"games": [...]}
+    live_data = {
+        "games": [
+            {"home": "Team A", "away": "Team B", "score": "89-86"},
+            {"home": "Team C", "away": "Team D", "score": "102-99"},
+        ]
+    }
     redis.setex("live_scores", 30, live_data)  # Cache for 30s
     return {"data": live_data, "source": "API"}
+
+
+@app.get("/player-stats/{player_id}")
+async def get_player_stats(player_id: str):
+    cache_key = f"player_stats:{player_id}"
+    cached_data = redis.get(cache_key)
+    if cached_data:
+        return {"data": cached_data, "source": "cache"}
+    # Fetch from external API (mock)
+    stats = {"id": player_id, "points": 25, "assists": 5}
+    redis.setex(cache_key, 30, stats)
+    return {"data": stats, "source": "API"}
+
+
+@app.get("/team-rankings")
+async def get_team_rankings():
+    cached_data = redis.get("team_rankings")
+    if cached_data:
+        return {"data": cached_data, "source": "cache"}
+    # Fetch from external API (mock)
+    rankings = {
+        "teams": [
+            {"name": "Team A", "rank": 1},
+            {"name": "Team B", "rank": 2},
+        ]
+    }
+    redis.setex("team_rankings", 30, rankings)
+    return {"data": rankings, "source": "API"}
+
+
+@app.on_event("startup")
+async def start_broadcast() -> None:
+    asyncio.create_task(broadcast_live_scores())
+
+
+async def broadcast_live_scores() -> None:
+    while True:
+        data = await get_live_scores()
+        await manager.broadcast(data)
+        await asyncio.sleep(5)
+
+
+@app.websocket("/ws/live-scores")
+async def websocket_live_scores(websocket: WebSocket) -> None:
+    client_ip = websocket.client.host
+    requests = redis.incr(client_ip)
+    if requests > 100:
+        await websocket.close(code=1008)
+        return
+    await manager.connect(websocket)
+    try:
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        manager.disconnect(websocket)

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,67 @@
+# Sports Data API
+
 Features:
-RESTful API for live scores, player stats, and team rankings.
+- RESTful API for live scores, player stats, and team rankings.
+- Caching with Redis to handle 10,000+ RPM (requests per minute).
+- Rate limiting (100 requests/minute) and Swagger documentation.
 
-Caching with Redis to handle 10,000+ RPM (requests per minute).
+## Endpoints
 
-Rate limiting (100 requests/minute) and Swagger documentation.
+### `GET /live-scores`
+Returns the latest game scores. Data is cached for 30 seconds.
+
+```
+{
+  "data": {
+    "games": [
+      {"home": "Team A", "away": "Team B", "score": "89-86"},
+      {"home": "Team C", "away": "Team D", "score": "102-99"}
+    ]
+  },
+  "source": "API"
+}
+```
+
+### `GET /player-stats/{player_id}`
+Retrieve statistics for a specific player.
+
+```
+GET /player-stats/23
+
+{
+  "data": {"id": "23", "points": 25, "assists": 5},
+  "source": "API"
+}
+```
+
+### `GET /team-rankings`
+Fetch the current team rankings.
+
+```
+{
+  "data": {
+    "teams": [
+      {"name": "Team A", "rank": 1},
+      {"name": "Team B", "rank": 2}
+    ]
+  },
+  "source": "API"
+}
+```
+
+### `WS /ws/live-scores`
+WebSocket endpoint that streams live score updates every few seconds.
+
+```javascript
+const ws = new WebSocket("ws://localhost:8000/ws/live-scores");
+ws.onmessage = (event) => console.log(JSON.parse(event.data));
+```
+
+## Running
+
+Start the API and Redis using Docker Compose:
+
+```
+docker-compose up
+```
+


### PR DESCRIPTION
## Summary
- add player stats API endpoint with Redis caching
- expose team rankings and document all endpoints
- stream live scores to connected WebSocket clients

## Testing
- `pytest`
- `docker-compose -v` *(fails: command not found)*
- `pip install docker-compose` *(fails: subprocess-exited-with-error)*
- `apt-get install -y docker-compose-plugin` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6890014dd9b08322aa8d0382323b2d72